### PR TITLE
cleanup: remove frosted option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pip install -r requirements.txt
 ```bash
 $ python generate.py --help
 usage: generate.py [-h] [--accent [accent color]]
-                   [--bg-alpha [background alpha]] [--frosted frosted effect]
+                   [--bg-alpha [background alpha]]
                    [--outer-gap [outer gap size]]
                    [--inner-gap [inner gap size]]
                    [--active-hint [active hint size]]
@@ -101,8 +101,6 @@ options:
                         The accent color to use for the theme.
   --bg-alpha [background alpha], -b [background alpha]
                         The alpha value of the background color.
-  --frosted frosted effect, -f frosted effect
-                        Whether to use frosted glass effect for the theme.
   --outer-gap [outer gap size], -o [outer gap size]
                         The size of the outer gap.
   --inner-gap [inner gap size], -i [inner gap size]

--- a/cosmic-settings/Catppuccin-Frappe-Blue.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Blue.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Green.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Green.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Lavender.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Mauve.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Peach.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Peach.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Pink.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Pink.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Red.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Red.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Yellow.ron
@@ -304,7 +304,6 @@
         blue: 0.42745098,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Blue.ron
+++ b/cosmic-settings/Catppuccin-Latte-Blue.ron
@@ -286,7 +286,6 @@
         blue: 0.96078431,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Green.ron
+++ b/cosmic-settings/Catppuccin-Latte-Green.ron
@@ -286,7 +286,6 @@
         blue: 0.16862745,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Latte-Lavender.ron
@@ -286,7 +286,6 @@
         blue: 0.99215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Latte-Mauve.ron
@@ -286,7 +286,6 @@
         blue: 0.93725490,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Peach.ron
+++ b/cosmic-settings/Catppuccin-Latte-Peach.ron
@@ -286,7 +286,6 @@
         blue: 0.04313725,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Pink.ron
+++ b/cosmic-settings/Catppuccin-Latte-Pink.ron
@@ -286,7 +286,6 @@
         blue: 0.79607843,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Red.ron
+++ b/cosmic-settings/Catppuccin-Latte-Red.ron
@@ -286,7 +286,6 @@
         blue: 0.22352941,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Latte-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Latte-Yellow.ron
@@ -286,7 +286,6 @@
         blue: 0.11372549,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Blue.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Blue.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Green.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Green.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Lavender.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Mauve.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Peach.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Peach.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Pink.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Pink.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Red.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Red.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Yellow.ron
@@ -304,7 +304,6 @@
         blue: 0.39215686,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Blue.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Blue.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Green.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Green.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Lavender.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Mauve.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Peach.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Peach.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Pink.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Pink.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Red.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Red.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Yellow.ron
@@ -304,7 +304,6 @@
         blue: 0.35294118,
         alpha: 1.0,
     )),
-    is_frosted: false,
     gaps: (0, 8),
     active_hint: 3,
 )

--- a/generate.py
+++ b/generate.py
@@ -33,15 +33,6 @@ parser.add_argument(
     help="The alpha value of the background color.",
 )
 parser.add_argument(
-    "--frosted",
-    "-f",
-    type=bool,
-    metavar="frosted effect",
-    dest="is_frosted",
-    default=False,
-    help="Whether to use frosted glass effect for the theme.",
-)
-parser.add_argument(
     "--outer-gap",
     "-o",
     type=int,
@@ -96,7 +87,6 @@ args = parser.parse_args()
 flavor = args.flavor
 accent = args.accent
 bg_alpha = args.bg_alpha
-is_frosted = args.is_frosted
 outer_gap_size = args.outer_gap_size
 inner_gap_size = args.inner_gap_size
 active_hint_size = args.active_hint_size
@@ -239,8 +229,7 @@ for color in other_map:
     )),"""
     )
 print(
-    f"""    is_frosted: {"true" if is_frosted else "false"},
-    gaps: ({outer_gap_size}, {inner_gap_size}),
+    f"""    gaps: ({outer_gap_size}, {inner_gap_size}),
     active_hint: {active_hint_size},
 )"""
 )


### PR DESCRIPTION
The frosted glass toggle was removed in cosmic-settings (see [this commit](https://github.com/pop-os/cosmic-settings/commit/d4bd120cbd3d61f02a3367fc836be82731532137))