### PR TITLE
Theme file fix for cosmic-settings so that they can be imported

### DIFF
--- a/cosmic-settings/Catppuccin-Frappe-Blue.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Blue.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Green.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Green.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Lavender.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Mauve.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Peach.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Peach.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Pink.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Pink.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Red.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Red.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Frappe-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Yellow.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Blue.ron
+++ b/cosmic-settings/Catppuccin-Latte-Blue.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Green.ron
+++ b/cosmic-settings/Catppuccin-Latte-Green.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Latte-Lavender.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Latte-Mauve.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Peach.ron
+++ b/cosmic-settings/Catppuccin-Latte-Peach.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Pink.ron
+++ b/cosmic-settings/Catppuccin-Latte-Pink.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Red.ron
+++ b/cosmic-settings/Catppuccin-Latte-Red.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Latte-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Latte-Yellow.ron
@@ -288,4 +288,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Blue.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Blue.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Green.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Green.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Lavender.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Mauve.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Peach.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Peach.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Pink.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Pink.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Red.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Red.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Macchiato-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Yellow.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Blue.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Blue.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Green.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Green.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Lavender.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Mauve.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Peach.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Peach.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Pink.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Pink.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Red.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Red.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/cosmic-settings/Catppuccin-Mocha-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Yellow.ron
@@ -306,4 +306,5 @@
     )),
     gaps: (0, 8),
     active_hint: 3,
+    is_frosted: false,
 )

--- a/generate.py
+++ b/generate.py
@@ -231,5 +231,6 @@ for color in other_map:
 print(
     f"""    gaps: ({outer_gap_size}, {inner_gap_size}),
     active_hint: {active_hint_size},
+    is_frosted: false,
 )"""
 )

--- a/generate.py
+++ b/generate.py
@@ -83,6 +83,16 @@ parser.add_argument(
     dest="window_hint_color",
     help="The color of the window hint.",
 )
+parser.add_argument(
+    "--is-frosted",
+    "-f",
+    type=str,
+    metavar="is frosted",
+    nargs="?",
+    default="false",
+    dest="is_frosted",
+    help="",
+)
 args = parser.parse_args()
 flavor = args.flavor
 accent = args.accent
@@ -92,6 +102,7 @@ inner_gap_size = args.inner_gap_size
 active_hint_size = args.active_hint_size
 roundness = args.roundness
 window_hint_color = accent if args.window_hint_color is None else args.window_hint_color
+is_frosted = args.is_frosted
 
 palette_map = {
     "blue": "blue",
@@ -231,6 +242,6 @@ for color in other_map:
 print(
     f"""    gaps: ({outer_gap_size}, {inner_gap_size}),
     active_hint: {active_hint_size},
-    is_frosted: false,
+    is_frosted: {is_frosted},
 )"""
 )


### PR DESCRIPTION
As they are now cosmic-settings .ron files don't load as themes upon clicking the "import" button, as they lack `is_frosted` field. This allows them to load properly.