### PR TITLE
fix(cosmic-settings): typo `Catpuccin` -> `Catppuccin`

### DIFF
--- a/cosmic-settings/Catppuccin-Frappe-Blue.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Blue.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Blue",
+        name: "Catppuccin-Frappe-Blue",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Frappe-Green.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Green.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Green",
+        name: "Catppuccin-Frappe-Green",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Frappe-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Lavender.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Lavender",
+        name: "Catppuccin-Frappe-Lavender",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Frappe-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Mauve.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Mauve",
+        name: "Catppuccin-Frappe-Mauve",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Frappe-Peach.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Peach.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Peach",
+        name: "Catppuccin-Frappe-Peach",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Frappe-Pink.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Pink.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Pink",
+        name: "Catppuccin-Frappe-Pink",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Frappe-Red.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Red.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Red",
+        name: "Catppuccin-Frappe-Red",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Frappe-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Frappe-Yellow.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Frappe-Yellow",
+        name: "Catppuccin-Frappe-Yellow",
         blue: (
             red: 0.54901961,
             green: 0.66666667,

--- a/cosmic-settings/Catppuccin-Latte-Blue.ron
+++ b/cosmic-settings/Catppuccin-Latte-Blue.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Blue",
+        name: "Catppuccin-Latte-Blue",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Latte-Green.ron
+++ b/cosmic-settings/Catppuccin-Latte-Green.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Green",
+        name: "Catppuccin-Latte-Green",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Latte-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Latte-Lavender.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Lavender",
+        name: "Catppuccin-Latte-Lavender",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Latte-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Latte-Mauve.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Mauve",
+        name: "Catppuccin-Latte-Mauve",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Latte-Peach.ron
+++ b/cosmic-settings/Catppuccin-Latte-Peach.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Peach",
+        name: "Catppuccin-Latte-Peach",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Latte-Pink.ron
+++ b/cosmic-settings/Catppuccin-Latte-Pink.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Pink",
+        name: "Catppuccin-Latte-Pink",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Latte-Red.ron
+++ b/cosmic-settings/Catppuccin-Latte-Red.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Red",
+        name: "Catppuccin-Latte-Red",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Latte-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Latte-Yellow.ron
@@ -1,6 +1,6 @@
 (
     palette: Light((
-        name: "Catpuccin-Latte-Yellow",
+        name: "Catppuccin-Latte-Yellow",
         blue: (
             red: 0.11764706,
             green: 0.40000000,

--- a/cosmic-settings/Catppuccin-Macchiato-Blue.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Blue.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Blue",
+        name: "Catppuccin-Macchiato-Blue",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Macchiato-Green.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Green.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Green",
+        name: "Catppuccin-Macchiato-Green",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Macchiato-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Lavender.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Lavender",
+        name: "Catppuccin-Macchiato-Lavender",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Macchiato-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Mauve.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Mauve",
+        name: "Catppuccin-Macchiato-Mauve",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Macchiato-Peach.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Peach.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Peach",
+        name: "Catppuccin-Macchiato-Peach",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Macchiato-Pink.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Pink.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Pink",
+        name: "Catppuccin-Macchiato-Pink",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Macchiato-Red.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Red.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Red",
+        name: "Catppuccin-Macchiato-Red",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Macchiato-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Macchiato-Yellow.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Macchiato-Yellow",
+        name: "Catppuccin-Macchiato-Yellow",
         blue: (
             red: 0.54117647,
             green: 0.67843137,

--- a/cosmic-settings/Catppuccin-Mocha-Blue.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Blue.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Blue",
+        name: "Catppuccin-Mocha-Blue",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/cosmic-settings/Catppuccin-Mocha-Green.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Green.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Green",
+        name: "Catppuccin-Mocha-Green",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/cosmic-settings/Catppuccin-Mocha-Lavender.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Lavender.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Lavender",
+        name: "Catppuccin-Mocha-Lavender",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/cosmic-settings/Catppuccin-Mocha-Mauve.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Mauve.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Mauve",
+        name: "Catppuccin-Mocha-Mauve",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/cosmic-settings/Catppuccin-Mocha-Peach.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Peach.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Peach",
+        name: "Catppuccin-Mocha-Peach",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/cosmic-settings/Catppuccin-Mocha-Pink.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Pink.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Pink",
+        name: "Catppuccin-Mocha-Pink",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/cosmic-settings/Catppuccin-Mocha-Red.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Red.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Red",
+        name: "Catppuccin-Mocha-Red",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/cosmic-settings/Catppuccin-Mocha-Yellow.ron
+++ b/cosmic-settings/Catppuccin-Mocha-Yellow.ron
@@ -1,6 +1,6 @@
 (
     palette: Dark((
-        name: "Catpuccin-Mocha-Yellow",
+        name: "Catppuccin-Mocha-Yellow",
         blue: (
             red: 0.53725490,
             green: 0.70588235,

--- a/generate.py
+++ b/generate.py
@@ -192,7 +192,7 @@ for color in eval(f"PALETTE.{flavor}.colors"):
 print(
     f"""(
     palette: {"Light" if flavor == "latte" else "Dark"}((
-        name: "Catpuccin-{flavor.capitalize()}-{accent.capitalize()}","""
+        name: "Catppuccin-{flavor.capitalize()}-{accent.capitalize()}","""
 )
 for color in palette_map:
     catppuccin_color = catppuccin_colors[palette_map[color]]


### PR DESCRIPTION

Not sure how I missed this one in the initial review...
