### PR TITLE
refactor: add whiskers check & remove justfile

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,17 @@
+name: whiskers
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  run:
+    uses: catppuccin/actions/.github/workflows/whiskers-check.yml@v1
+    with:
+      args: |
+        templates/cosmic-settings.tera
+        templates/cosmic-term.tera
+    secrets: inherit

--- a/justfile
+++ b/justfile
@@ -1,9 +1,0 @@
-_default:
-  @just --list
-
-clean:
-  rm -rf themes
-
-build: clean
-  whiskers templates/cosmic-settings.tera
-  whiskers templates/cosmic-term.tera

--- a/templates/cosmic-settings.tera
+++ b/templates/cosmic-settings.tera
@@ -7,7 +7,7 @@ outer_gap_size: 0
 inner_gap_size: 8
 active_hint_size: 3
 whiskers:
-    version: 2.5.1
+    version: ^2.5.1
     matrix:
     - flavor
     - accent

--- a/templates/cosmic-term.tera
+++ b/templates/cosmic-term.tera
@@ -1,6 +1,6 @@
 ---
 whiskers:
-    version: 2.5.1
+    version: ^2.5.1
     matrix:
     - flavor
     filename: "themes/cosmic-term/catppuccin-{{ flavor.identifier }}.ron"


### PR DESCRIPTION
We now have a reusable workflow for checking whiskers in CI, which is to be used
across the organisation. Note that whiskers will soon start to recommend `^` in
front of the version.

We have also made the decision to remove justfiles from repositories where the
build command is trivial.